### PR TITLE
Path to SassDocs in readme not accurate

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ You **do not** need to clone the repo to use the tools, just to see examples and
 
 ### Docs
 
-After building the tools, you can see the [SassDocs](http://sassdoc.com) at `docs/`.
+After building the tools, you can see the [SassDocs](http://sassdoc.com) at `/docs/sassdoc/index.html`.
 
 ### Building the Tools
 

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ You **do not** need to clone the repo to use the tools, just to see examples and
 
 ### Docs
 
-After building the tools, you can see the [SassDocs](http://sassdoc.com) at `/docs/sassdoc/index.html`.
+After building the tools, you can see the [SassDocs](http://sassdoc.com) at `docs/sassdoc/index.html`.
 
 ### Building the Tools
 


### PR DESCRIPTION
Weirdly, going to `/docs/sassdoc/` gets me a funky Windows-ish file browser:

<img width="499" alt="screen shot 2017-08-06 at 4 54 59 pm" src="https://user-images.githubusercontent.com/79733/29008232-23ea47b0-7ac8-11e7-9449-94a46e40269d.png">

I have to go to `index.html` to actually see the docs.