### PR TITLE
Setting smart grid to border-box

### DIFF
--- a/lib/_smart-grid.scss
+++ b/lib/_smart-grid.scss
@@ -41,7 +41,14 @@ $smart-grid-selector: '.smart-grid' !default;
 @mixin smart-grid($row-items: 4, $gutter: $smart-grid-gutter) {
   display: flex;
   flex-wrap: wrap;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+
   > * {
+    -webkit-box-sizing: inherit;
+    -moz-box-sizing: inherit;
+    box-sizing: inherit;
     margin-bottom: $gutter;
     @if $row-items > 1 {
       width: grid-width($smart-grid-columns / $row-items);


### PR DESCRIPTION
This fixes the border-box problem I outlined in [this issue](https://github.com/theme-tools/sass-tools/issues/3). I'm not sure this is the preferred approach, but the smart grid setup on my project now is the same in both PL and it's Drupal implementation. 